### PR TITLE
centralize room description generation

### DIFF
--- a/DiscordBot/commands/mud/look.js
+++ b/DiscordBot/commands/mud/look.js
@@ -4,6 +4,7 @@ const {
   checkItems,
   checkKeys,
   commandPrefix,
+  generateRoomDescription,
   sendMessageRoom,
   sendMessagePrivate, 
 } = require('../../utilities/globals');
@@ -107,7 +108,7 @@ class LookCommand extends commando.Command {
       var object;
       if (objectIsRoom === true) {
         object = room;
-        object.description = `${object.description}\nExits are: ${Object.keys(object.exits).toString()}`;
+        object.description = generateRoomDescription(object);
       } else {
         var body = JSON.parse(data.body);
         var item = body.Item;

--- a/DiscordBot/commands/mud/move.js
+++ b/DiscordBot/commands/mud/move.js
@@ -2,6 +2,7 @@ const {
   deleteMessage,
   bigCheck,
   commandPrefix,
+  generateRoomDescription,
   sendMessagePrivate,
   sendMessageRoom,
   updateRoomPopulace
@@ -45,7 +46,7 @@ class MoveCommand extends commando.Command {
     // if we're grabbing the room that the player is moving to, assign the player the new room's role ID
     getItem(nextRoom.id, 'rooms', (data) => updateRoomPopulace(data, player, 'add'));
     updateItem(player.id, ['currentRoomId'], [nextRoom.id], 'players');
-    sendMessagePrivate(message, nextRoom.description);
+    sendMessagePrivate(message, generateRoomDescription(nextRoom));
     sendMessageRoom(this.client,`${player.characterName} has entered.`, nextRoom);
   }
 

--- a/DiscordBot/utilities/globals.js
+++ b/DiscordBot/utilities/globals.js
@@ -135,6 +135,10 @@ function inventoryAddItem(itemData, player, callback) {
   );
 }
 
+function generateRoomDescription(roomObject) {
+  return `${roomObject.description}\nExits are: ${Object.keys(roomObject.exits).toString().replace(/,/g, ', ')}`;
+}
+
 /* 
   player specific messaging that can be triggered anywhere,
   but should only ever be sent to the player directly.
@@ -186,6 +190,7 @@ module.exports = {
   emojiCheck,
   emojiOn,
   gameWorldName,
+  generateRoomDescription,
   inventoryAddItem,
   respawn,
   sendMessagePrivate,


### PR DESCRIPTION
closes #74 

Adds:
- [x] global room description generator function

Modifies:
- [x] replaced room description output in Move and Look